### PR TITLE
fix: on tap cancel floating button

### DIFF
--- a/lib/widgets/buttons/neopop_tilted_button/neopop_tilted_button.dart
+++ b/lib/widgets/buttons/neopop_tilted_button/neopop_tilted_button.dart
@@ -365,7 +365,8 @@ class _NeoPopTiltedButtonState extends State<NeoPopTiltedButton>
     moveDown();
   }
 
-  void floatingOnTapCancel() {
+  Future<void> floatingOnTapCancel() async {
+    await moveUp();
     posFactor = widget.yPosFactor ?? kTiltedButtonYPosFactor;
     startFloating();
   }


### PR DESCRIPTION
When we drag away from floating button, it doesn't move back to its expected position. 

https://user-images.githubusercontent.com/72645766/177755915-d07814a3-bf2b-4ec5-8d21-48a3ea75582c.mp4


https://user-images.githubusercontent.com/72645766/177755932-c3dda058-bf4f-4e5b-98a0-d9b37354564a.mp4

